### PR TITLE
Fix logo path in carrito.html

### DIFF
--- a/carrito.html
+++ b/carrito.html
@@ -12,7 +12,7 @@
 
   <header>
     <a href="index.html" class="back-to-home">← Volver al inicio</a>
-    <img src="logo.png" alt="Logo Florería Cristina" />
+    <img src="https://i.postimg.cc/RZ34GxdP/Logo-Crsitina.png" alt="Logo Florería Cristina" />
     <h1>Carrito de Compras</h1>
     <div class="cart-summary">
       <i class="fas fa-shopping-cart"></i>


### PR DESCRIPTION
## Summary
- update the carrito page to use the remote logo URL instead of a local file

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861c4d2133c83289f88dff42d2d35e0