### PR TITLE
Fix logo path on cart page

### DIFF
--- a/carrito.html
+++ b/carrito.html
@@ -12,7 +12,7 @@
 
   <header>
     <a href="index.html" class="back-to-home">← Volver al inicio</a>
-    <img src="logo.png" alt="Logo Florería Cristina" />
+    <img src="https://i.postimg.cc/RZ34GxdP/Logo-Crsitina.png" alt="Logo Florería Cristina" />
     <h1>Carrito de Compras</h1>
     <div class="cart-summary">
       <i class="fas fa-shopping-cart"></i>


### PR DESCRIPTION
## Summary
- use same logo URL as other pages for `carrito.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68629cf1d3908328a613815a7ebf64c4